### PR TITLE
A Solaris-friendly pam_cracklib

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,16 @@
+pam_cracklib - password cracking PAM module that builds on Solaris
+Copyright (C) 2003 Krzysztof Majewski <krzys.m.majewski@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   
+For a copy of the GNU General Public License go to http://www.gnu.org
+or write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, 
+Boston, MA  02111-1307  USA

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,71 @@
+# !!! Hello !!!
+# Make sure you are using GNU Make, and not some cheap imitation.
+# !!! Thank you !!!
+
+OS=$(shell uname)
+ARCH=$(shell uname -p)
+CRACKLIB_TARGET=pam_cracklib.so
+DESTDIR=/usr/opt/lib/security
+PERMS=0700
+PASSWORD_SRCS=pam_password.c
+COMMON_SRCS=pam_module.c logging.c util.c
+CRACKLIB_SRCS=cracklib.c $(COMMON_SRCS) $(PASSWORD_SRCS)
+CRACKLIB_OBJS=$(CRACKLIB_SRCS:.c=.o)
+DICTPATH="/usr/opt/cracklib/pw_dict"
+INCL=
+LIBS=-lpam
+CRACK_LIBS=-lcrack
+CC=gcc
+CFLAGS=-g -Wall -fPIC -D$(OS) -D$(ARCH)
+LD=ld
+ifeq ($(OS),SunOS) 
+LDFLAGS=-G -z redlocsym -L/usr/opt/lib -R/usr/opt/lib
+else
+LDFLAGS=-x --shared -L/usr/opt/lib -R/usr/opt/lib
+endif
+RM=rm
+FORCE_REBUILD=
+
+password:	$(CRACKLIB_TARGET)
+
+# We will use this when cproto(1) stops sucking
+# %.h : %.c $(FORCE_REBUILD) # A ".o" file depends on the corresponding ".c" file
+# 	cproto -E 0 $< 
+
+%.o : %.c $(FORCE_REBUILD) # A ".o" file depends on the corresponding ".c" file
+	$(CC) $(INCL) $(CFLAGS) -c $< -o $@ 
+
+% : %.o # override default linking rule just in case
+	@echo
+	@echo $@ is not a valid target
+	@echo
+
+$(CRACKLIB_TARGET) : CFLAGS += -DMODULE_NAME=\"$(CRACKLIB_TARGET)\"  -DCRACKLIB_DICTPATH=\"$(DICTPATH)\"
+$(CRACKLIB_TARGET) : $(FORCE_REBUILD) $(CRACKLIB_OBJS)
+	$(LD) $(LDFLAGS) -o $@ $(CRACKLIB_OBJS) $(LIBS) $(CRACK_LIBS)
+	@echo
+	@echo $@ built successfully!
+	@echo
+
+# Need -O so the inline "stat()" gets compiled, grr
+$(DESTDIR)/$(CRACKLIB_TARGET) : $(CRACKLIB_TARGET)
+	@echo installing...
+	test -d $(DESTDIR) || mkdir -p $(DESTDIR)
+	cp $(CRACKLIB_TARGET) $(DESTDIR)
+	chown root $(DESTDIR)/$(CRACKLIB_TARGET)
+	chgrp root $(DESTDIR)/$(CRACKLIB_TARGET)
+	chmod $(PERMS) $(DESTDIR)/$(CRACKLIB_TARGET)
+
+$(FORCE_REBUILD):
+	@echo rebuilding...
+
+install: $(DESTDIR)/$(CRACKLIB_TARGET)
+
+rebuild:
+	$(MAKE) $(MOREMAKEFLAGS) "FORCE_REBUILD=REBUILD"
+
+clean:
+	$(RM) -f $(CRACKLIB_TARGET)
+	$(RM) -f $(CRACKLIB_OBJS)
+	$(RM) -f #*
+	$(RM) -f *~

--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,10 @@
+Make sure you have cracklib - you'll need the header packer.h,
+the shared library libcrack.so, and a dictionary compiled to work with
+cracklib. One way to satisfy this requirement is to search the net for
+Alec Muffett's cracklib, download it, build it, and install it. 
+But there may be other ways. (This package does not come with any
+part of cracklib.)
+
+Make sure you have GNU make. 
+Look through the GNUmakefile. 
+Type 'make' to build, 'make install' (as root) to install.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+# My makefile exploits features of GNU Make that other Makes
+# do not have.  Because it is a common mistake for people to try to build
+# stuff with a different Make, I have this makefile that does nothing
+# but tell the user to use GNU Make.
+
+# If the user were using GNU Make now, this file would not get used because
+# GNU Make uses a makefile named "GNUmakefile" in preference to "Makefile"
+# if it exists.  We have a "GNUmakefile".
+
+all merge install clean dep:
+	@echo "You must use GNU Make to build this stuff.  You are running "
+	@echo "some other Make.  GNU Make may be installed on your system "
+	@echo "with the name 'gmake'.  If not, see "
+	@echo "http://www.gnu.org/software ."
+	@echo

--- a/README
+++ b/README
@@ -1,0 +1,14 @@
+PAM module for password cracking. Builds on Solaris!
+
+Usage is to put something like this in /etc/pam.d/ (Linux) 
+or /etc/pam.conf (Solaris):
+
+passwd  auth		required        /usr/lib/security/$ISA/pam_passwd_auth.so.1
+passwd  password        required        /usr/lib/security/$ISA/pam_authtok_get.so.1
+passwd  password        requisite       /usr/opt/lib/security/pam_cracklib.so use_authtok 
+passwd  password        required        /usr/lib/security/$ISA/pam_authtok_store.so.1 
+
+Putting "debug" at the end of the line will result in verbose logging 
+(do this when something breaks).
+
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# solaris_pam_cracklib
-A pam_cracklib that builds on Solaris

--- a/constants.h
+++ b/constants.h
@@ -1,0 +1,10 @@
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
+
+#define RANDOM_LENGTH 1000 /* Welcome to the C language */
+#define HELPMAIL "<help@localhost>"
+#define GDB_WAIT 30
+#define ERROR_WAIT 10
+#define INFO_WAIT 5
+
+#endif

--- a/cracklib.c
+++ b/cracklib.c
@@ -1,0 +1,44 @@
+/**
+ * Run Alec Muffett's cracklib on a putative new password
+ * Unlike the original pam_cracklib, this is intended to build on Sun machines
+ *
+ */
+
+#include "/usr/opt/include/packer.h"
+#include "pam_password.h"
+#include "logging.h"
+#include "util.h"
+#include "cracklib.h"
+
+#ifdef MODULE_NAME
+char *_moduleName=MODULE_NAME;
+#else
+#error "You must define MODULE_NAME"
+#endif
+
+char *
+getModuleName(pam_handle_t *pamh)
+{
+  return _moduleName;
+}
+
+int
+crack(pam_handle_t *pamh, const char *pw)
+{
+  int result=1;
+  const char *msg=NULL;
+  //  chop(pw);
+  msg=FascistCheck(pw,CRACKLIB_DICTPATH);
+  if (msg) {
+    char sorry[RANDOM_LENGTH];
+    strncpy(sorry,
+	    "Your new password was rejected for the following reason:\n",
+	    RANDOM_LENGTH);
+    strncat(sorry, msg, RANDOM_LENGTH);
+    pamErrorMessage(pamh, sorry);
+  } else {
+    result = 0;
+    pamInfoMessage(pamh, "New password OK");
+  }
+  return result;
+}

--- a/cracklib.h
+++ b/cracklib.h
@@ -1,0 +1,7 @@
+/**
+ * Returns non-zero value if password is cracked by cracklib
+ *
+ */
+
+int
+crack(pam_handle_t *pamh, const char *pw);

--- a/logging.c
+++ b/logging.c
@@ -1,0 +1,34 @@
+#include "varargs.h"
+#include "logging.h"
+
+void
+_perror(char *format, ...)
+{
+  VA_LIST ap;
+  int _errno = errno;
+  const char *errorString=strerror(_errno);
+  char syslogString[RANDOM_LENGTH]; // Why C sucks
+  char suffix[RANDOM_LENGTH];
+  char valueAddedFormat[RANDOM_LENGTH];
+
+  VA_START(ap,format);
+  sprintf(suffix, " (%s)", errorString?errorString:"Unknown error");
+  strcpy(valueAddedFormat, format);
+  strcat(valueAddedFormat, suffix);
+  vsprintf(syslogString, valueAddedFormat, ap); 
+  syslog(LOG_ERR, syslogString);
+  VA_END(ap);
+}
+
+void
+_error(pam_handle_t *pamh, int errnum, char *file, int line)
+{
+  const char *errorString=pam_strerror(pamh,errnum);
+  char syslogString[RANDOM_LENGTH]; // Why C sucks
+
+  sprintf(syslogString,
+	  "[%s:%d] %s", 
+	  file, 
+	  line, 
+	  errorString?errorString:"Unknown PAM error");
+}

--- a/logging.h
+++ b/logging.h
@@ -1,0 +1,35 @@
+#ifndef LOGGING_H
+#define LOGGING_H
+
+#include <stdio.h>
+#include <syslog.h>
+#include <errno.h>
+#include <string.h>
+#ifdef SunOS
+#include <security/pam_appl.h>
+#endif
+#include <security/pam_modules.h>
+#include "constants.h"
+#include "util.h"
+
+#ifndef YPERR_SUCCESS
+#define YPERR_SUCCESS 0
+#endif
+
+#define DEBUG(format, ...)  if (isDebuggingOn()) syslog(LOG_DEBUG, "[%s:%d] " format, __FILE__, __LINE__ , ## __VA_ARGS__)
+#define ERROR(format, ...) syslog(LOG_ERR , "[%s:%d] " format, __FILE__, __LINE__ , ## __VA_ARGS__)
+#define PERROR(format, ...) _perror("[%s:%d] " format, __FILE__, __LINE__ , ## __VA_ARGS__)
+#define PAM_ERROR(errnum)  _error(pamh, errnum, __FILE__, __LINE__)
+#define ASSERT if (result != PAM_SUCCESS) {return result;}
+#define NOTNULL(x) if (x == NULL) {syslog(LOG_ERR,"[%s:%d] Unexpected NULL pointer", __FILE__, __LINE__); result=PAM_AUTHTOK_ERR; return result;}
+#define NONZERO(x) if (x == 0) {syslog(LOG_ERR,"[%s:%d] Unexpected zero value", __FILE__, __LINE__); result=PAM_AUTHTOK_ERR; return result;}
+#define NOT_IMPLEMENTED syslog(LOG_ERR,"[%s:%d] Not implemented yet", __FILE__ , __LINE__); result=PAM_AUTHTOK_ERR; return result;
+#define YP_ASSERT if (yperr != YPERR_SUCCESS) {syslog(LOG_ERR,"[%s:%d] ypclnt error (%s)", __FILE__, __LINE__, yperr_string(yperr)); result=PAM_AUTHTOK_ERR; return result;}
+
+void
+_perror(char *format, ...);
+
+void
+_error(pam_handle_t *pamh, int errnum, char *file, int line);
+
+#endif

--- a/pam_module.c
+++ b/pam_module.c
@@ -1,0 +1,251 @@
+/**
+ *
+ * Generic framework for a PAM module 
+ *
+ */
+
+/**
+ *
+ * TODO: 
+ * - make sure syslog doesn't break application's logging
+ *
+ */
+
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include <unistd.h>
+#include <malloc.h>
+#include <string.h>
+#include "logging.h"
+#include "pam_module.h"
+#include "util.h"
+#include "constants.h"
+
+static const char *_cookedService = NULL;
+
+static void
+_setCookedService(pam_handle_t *pamh)
+{
+  char service[RANDOM_LENGTH];
+  static char cookedService[RANDOM_LENGTH];
+  PAM_GET_ITEM(pamh,PAM_SERVICE,(void **)(&service));
+  cookService(service,cookedService);
+  _cookedService = cookedService;
+}
+
+static int
+_hasGui(pam_handle_t *pamh)
+{
+  int result = 0;
+  if (_cookedService == NULL) {
+    _setCookedService(pamh);
+  }
+  result = !strncmp(_cookedService,"xdm",RANDOM_LENGTH);
+  return result;
+}
+
+/**
+ *
+ *  This function should be called via the PAM_GET_ITEM macro.
+ *
+ *  Possible keys are:
+ *      PAM_SERVICE (eg "sshd")  
+ *      PAM_USER (eg "majewski")  
+ *      PAM_USER_PROMPT  
+ *      PAM_TTY (eg "/dev/pts/1") 
+ *      PAM_RUSER  
+ *      PAM_RHOST (eg "okocim.cs.ubc.ca") 
+ *      PAM_CONV 
+ *      PAM_FAIL_DELAY 
+ *
+ */
+int
+_pamGetItem(pam_handle_t *pamh, int key, const char *keyName, void **valuep)
+{
+  int result;
+  NOTNULL(valuep);
+  result = pam_get_item(pamh, key,
+#ifdef Linux
+			(const void **)
+#else
+			(void **)
+#endif			
+			valuep);
+  if (result != PAM_SUCCESS) {
+    PAM_ERROR(result);
+    *valuep = NULL;
+  } else if (*valuep == NULL) {
+    result=PAM_SESSION_ERR;
+    DEBUG("No value found for key '%s'", keyName);
+  } else {
+    if ( (key != PAM_AUTHTOK) && (key != PAM_OLDAUTHTOK)) {
+      DEBUG("Found value '%s' for key '%s'", (char *)(*valuep), keyName);
+    } else {
+      int len,i;
+      char xxx[RANDOM_LENGTH+1];
+      len=strlen((char*)(*valuep));
+      for(i=0;(i<RANDOM_LENGTH) && (i<len);i++){
+	xxx[i]='x';
+      }
+      xxx[i]='\0';
+      DEBUG("Found value '%s' for key '%s'", xxx, keyName);
+    }
+  }
+  return result;
+}
+
+int
+_pamSetItem(pam_handle_t *pamh, int key, const char *keyName, const void *val)
+{
+  int result;
+  char *sanity = NULL;
+  if ( (key != PAM_AUTHTOK) && (key != PAM_OLDAUTHTOK)) {  
+    DEBUG("setting '%s' to '%s'", keyName, (char *)val);
+  } else {
+    int len,i;
+    char xxx[RANDOM_LENGTH+1];
+    NOTNULL(val);
+    len=strlen((char*)val);
+    for(i=0;(i<RANDOM_LENGTH) && (i<len);i++){
+      xxx[i]='x';
+    }
+    xxx[i]='\0';
+    DEBUG("setting '%s' to '%s'", keyName, xxx);
+  }
+  result = pam_set_item(pamh, key,
+#ifdef Linux
+			(const void *)
+#else
+			(void *)
+#endif
+			val);
+  result = pam_get_item(pamh,key,(void **)&sanity);
+  if ((sanity == NULL) || (strncmp(sanity,(char *)val,RANDOM_LENGTH))) {
+    ERROR("sanity check failed");
+  }
+  sanity=NULL;
+  if (result != PAM_SUCCESS) {
+    PAM_ERROR(result);
+  }
+  return result;
+}
+    
+static int 
+_pamMessage(pam_handle_t *pamh, 
+#ifdef Linux
+	    const char *message,
+#else
+	    char *message,
+#endif
+	    int style);
+
+int
+pamErrorMessage(pam_handle_t *pamh, 
+#ifdef Linux
+		const char *message
+#else
+		char *message
+#endif
+		)
+{
+  return _pamMessage(pamh,message,PAM_ERROR_MSG);
+}
+
+int
+pamInfoMessage(pam_handle_t *pamh, 
+#ifdef Linux
+		const char *message
+#else
+		char *message
+#endif
+	       )
+{
+  return _pamMessage(pamh,message,PAM_TEXT_INFO);
+}
+
+int
+_pamMessage(pam_handle_t *pamh, 
+#ifdef Linux
+	    const char *message,
+#else
+	    char *message,
+#endif
+	    int style)
+{
+  typedef struct pam_message PAM_MESSAGE;
+  typedef struct pam_response PAM_RESPONSE;
+  int result=PAM_SUCCESS;
+  struct pam_conv *pamConv=NULL;
+  PAM_MESSAGE pamMessage; 
+  PAM_MESSAGE **messages;
+  PAM_RESPONSE *pamResponses; 
+
+  NOTNULL(message);
+  result=PAM_GET_ITEM(pamh,PAM_CONV,(void **)&pamConv);
+  if (result != PAM_SUCCESS) {
+    ERROR("Couldn't get item PAM_CONV");
+  }
+  NOTNULL(pamConv);
+  NOTNULL(pamConv->conv);
+  pamMessage.msg_style=style;
+  pamMessage.msg=message;
+  messages = calloc(1,sizeof(PAM_MESSAGE *)); 
+  if (messages == NULL) {
+    PERROR("calloc failed");
+    result = PAM_SESSION_ERR;
+    return result;
+  }
+  messages[0]=&pamMessage;
+  DEBUG("sending message to application: '%s'", messages[0]->msg);
+  result=pamConv->conv(1, 
+#ifdef Linux
+		       /* unnecessary cast: gcc bug or programmer brain bug? */
+  		       (const PAM_MESSAGE **)messages,
+#else
+		       messages,
+#endif
+		       &pamResponses, 
+		       NULL);
+  if (result != PAM_SUCCESS) {
+    PAM_ERROR(result);
+  } else {
+    /* give them time to read the message if need be*/
+    if (_hasGui(pamh)) {
+      int seconds = (style==PAM_ERROR_MSG) ? ERROR_WAIT : INFO_WAIT;
+      DEBUG("sleeping for %d seconds...", seconds);
+      sleep(seconds);
+    }
+  }
+  if (pamResponses != NULL) {
+    free(pamResponses);
+  }
+  free(messages);
+  return result;
+}
+
+int
+getArg(int argc, const char **argv, const char *key, void **value)
+{
+  int i;
+  int result=0;
+  NOTNULL(key);
+  NOTNULL(argv);
+  for (i=0; i<argc; i++) {
+    const char *arg = argv[i];
+    int keyLength = strlen(key);
+    int argLength = strlen(arg);
+    // holy buffer overflow, batman
+    if (!strncmp(key,arg,keyLength)) {
+      result=1;
+      if ((argLength > keyLength) && (arg[keyLength] == '=')) {
+	if (value) {
+	  NOTNULL(*value);
+	  strncpy(*value, arg+keyLength+1, argLength-keyLength-1);
+	  strcpy((*value)+argLength-keyLength-1,"\0");
+	}
+      }
+      break;
+    }
+  }
+  return result;
+}

--- a/pam_module.h
+++ b/pam_module.h
@@ -1,0 +1,54 @@
+#ifndef PAM_MODULE_H
+#define PAM_MODULE_H
+
+/**
+ * A generic interface for PAM modules
+ *
+ */
+
+#ifdef SunOS
+#include <security/pam_appl.h>
+#endif
+#include <security/pam_modules.h>
+
+#ifdef Linux
+#define LOG_FACILITY LOG_AUTHPRIV
+#else
+#define LOG_FACILITY LOG_AUTH
+#endif
+
+#define PAM_GET_ITEM(pam_handle, key, valuep) _pamGetItem(pam_handle, key, #key, valuep)
+
+#define PAM_SET_ITEM(pam_handle, key, val) _pamSetItem(pam_handle, key, #key, val)
+
+int
+_pamGetItem(pam_handle_t *pamh, int key, const char *keyName, void **valuep);
+
+int
+_pamSetItem(pam_handle_t *pamh, int key, const char *keyName, const void *val);
+
+int
+getArg(int argc, const char **argv, const char *key, void **value);
+  
+int
+pamErrorMessage(pam_handle_t *pamh, 
+#ifdef Linux
+		const char *message
+#else
+		char *message
+#endif
+		);
+
+int
+pamInfoMessage(pam_handle_t *pamh, 
+#ifdef Linux
+		const char *message
+#else
+		char *message
+#endif
+		);
+
+extern char *
+getModuleName(pam_handle_t *pamh);
+
+#endif

--- a/pam_password.c
+++ b/pam_password.c
@@ -1,0 +1,141 @@
+/**
+ *
+ * Generic framework for a PAM module of the "password" type
+ * (Perhaps not generic enough...)
+ * Currently this object performs no authentication, nor does
+ * it get or store authentication tokens in the passwd map.
+ * You should ensure that these functions are performed by the rest
+ * of your PAM stack.
+ *
+ */
+
+/**
+ *
+ * TODO: 
+ * - make sure syslog doesn't break application's logging
+ *
+ */
+#define PAM_SM_PASSWORD
+
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include <unistd.h>
+#include <malloc.h>
+#include <string.h>
+#include "logging.h"
+#include "pam_password.h"
+#include "util.h"
+#include "constants.h"
+#include "cracklib.h"
+
+static void
+_post(pam_handle_t *pamh,
+      int result)
+{
+  if (result != PAM_SUCCESS) {
+    PAM_ERROR(result);
+  } else {
+    DEBUG("Successfully changed authorization tokens.");
+  }
+  closelog();
+}
+
+static int
+_pre(pam_handle_t *pamh,
+     int flags,
+     int argc,
+     const char ** argv)
+{
+  int result=PAM_SUCCESS;
+  char *const *envList = pam_getenvlist(pamh);
+  int i;
+  openlog(getModuleName(pamh),0,LOG_FACILITY);
+  for (i=0; i<argc; i++) {
+    if (strcmp("debug",argv[i])==0) {
+      turnOnDebugging();
+    } else if (strcmp("gdb",argv[i])==0) {
+      enableGdb();
+    } else if (strcmp("use_authtok",argv[i])) {
+      ERROR("Unrecognized argument '%s'", argv[i]);
+      ERROR("Check your /etc/pam.d/* or /etc/pam.conf");
+      result=PAM_AUTHTOK_ERR;
+      return result;
+    }
+  }
+  //  DEBUG("Changing authorization tokens...");
+  if (isGdbEnabled()) {
+    // use syslog directly in case they haven't passed the "debug" flag
+    syslog(LOG_DEBUG, "My PID is %d", getpid());
+    syslog(LOG_DEBUG, "Waiting %d seconds for debugger...", GDB_WAIT);
+    sleep(GDB_WAIT);
+    syslog(LOG_DEBUG, "Done waiting.");
+  }
+  for (;*envList != NULL;envList++) {
+    DEBUG("%s",*envList);
+  }
+  return result;
+}
+
+/**
+ * 
+ * Hook called by libPAM
+ *
+ */
+#ifdef Linux
+PAM_EXTERN 
+#endif
+int
+pam_sm_chauthtok(pam_handle_t *pamh,
+		 int flags,
+		 int argc,
+		 const char **argv)
+{
+  int result=PAM_SUCCESS;
+  if (flags & PAM_PRELIM_CHECK) {
+    char *oldpw = NULL;
+    result = _pre(pamh, flags, argc, argv);
+    DEBUG("called with flag PAM_PRELIM_CHECK");
+    if (getArg(argc, argv, "use_authtok", NULL)) {
+      result = PAM_GET_ITEM(pamh, PAM_OLDAUTHTOK, (void **)&oldpw);
+      oldpw=NULL; // just checking if we can get it
+      if (result != PAM_SUCCESS) {
+	ERROR("Couldn't get item PAM_OLDAUTHTOK");
+	return PAM_TRY_AGAIN;
+      }
+    } else {
+      ERROR("You must supply the use_authtok argument for now");
+      return PAM_AUTHTOK_ERR;
+    }
+  } else if (flags & PAM_UPDATE_AUTHTOK) {
+    char *newpw = NULL;
+    char pw[9];
+    DEBUG("called with flag PAM_UPDATE_AUTHTOK");    
+    if (getArg(argc, argv, "use_authtok", NULL)) {
+      result = PAM_GET_ITEM(pamh, PAM_AUTHTOK, (void **)&newpw);
+      if (result != PAM_SUCCESS) {
+	ERROR("Couldn't get item PAM_AUTHTOK");
+	return result;
+      }
+    } else {
+      ERROR("You must supply the use_authtok argument for now");
+      return PAM_AUTHTOK_ERR;
+    }
+    NOTNULL(newpw);
+    strncpy(pw,newpw,8); // our NIS only does 8-character passwords
+    pw[8]='\0';
+    if (!crack(pamh,pw)) {
+      PAM_SET_ITEM(pamh, PAM_AUTHTOK, pw);
+      //      PAM_SET_ITEM(pamh, PAM_REPOSITORY, "nis"); //segfaults
+    } else {
+      result=PAM_AUTHTOK_ERR;
+    }
+    memset(pw,0,8);
+    newpw=NULL;
+    _post(pamh,result);
+    DEBUG("PAM result = %d\n", result);
+  } else {
+    ERROR("bad flags: %d\n", flags);
+    result = PAM_SERVICE_ERR;
+  }
+  return result;
+}

--- a/pam_password.h
+++ b/pam_password.h
@@ -1,0 +1,19 @@
+#ifndef PAM_PASSWORD_H
+#define PAM_PASSWORD_H
+
+/**
+ * A generic interface for PAM modules of the "password" type
+ *
+ */
+
+#ifdef SunOS
+#include <security/pam_appl.h>
+#endif
+#include <security/pam_modules.h>
+
+#include "pam_module.h"
+
+extern int
+changeAuthorizationTokens(pam_handle_t *pamh, int flags);
+
+#endif

--- a/util.c
+++ b/util.c
@@ -1,0 +1,237 @@
+#ifdef SunOS
+#include <security/pam_appl.h>
+#endif
+#include <security/pam_modules.h>
+#include <unistd.h>
+#include <rpcsvc/ypclnt.h>
+#include <stdlib.h>
+#include <pwd.h>
+#include "logging.h"
+#include "constants.h"
+#include "util.h"
+
+/* Will this be shared between all instances of the module? */
+static int debug=0;
+static int gdb=0; 
+
+int
+getHomeDir(char *user, char *homeDir)
+{
+  int result=PAM_SUCCESS;
+  struct passwd *p;
+  NOTNULL(user);
+  NOTNULL(homeDir);
+  p = getpwnam(user);
+  NOTNULL(p);
+  NOTNULL(p->pw_dir);
+  strcpy(homeDir,p->pw_dir);
+  return result;
+}
+
+int 
+getUID(char *user)
+{
+  struct passwd *p;
+
+  if (user == NULL || *user == 0) {
+    return 0;
+  }
+  if (*user >= '0' && *user <= '9') {
+    return atoi(user);
+  }
+  p = getpwnam(user);
+  if (p == NULL) {
+    return 0;
+  } else {
+    return p->pw_uid;
+  }
+}
+
+int
+isDebuggingOn()
+{
+  return (debug!=0);
+}
+
+void
+turnOnDebugging()
+{
+  debug=1;
+}
+
+int
+isGdbEnabled()
+{
+  return (gdb!=0);
+}
+
+void
+enableGdb()
+{
+  gdb=1;
+}
+
+void
+cookService(char *service, char *cookedService)
+{
+  if ((strcmp(service,"dtlogin")==0) ||
+      (strcmp(service,"gdm")==0) ||
+      (strcmp(service,"kdm")==0)) 
+    {
+      strcpy(cookedService,"xdm");
+    } else {
+      strcpy(cookedService,service);
+    }
+}
+
+int
+sessid(char *tty, char *id)
+{
+  int result=PAM_SUCCESS;
+  char sessbuf[512];
+  char *p, tty0[512];
+
+  DEBUG("Generating sessid...");
+  if( !tty || tty[0] == 0 ) {
+    snprintf(tty0, 512, "%d", (int)getpid());
+  } else {
+    strncpy(tty0, tty, 512);
+  }
+  if (gethostname(sessbuf, sizeof(sessbuf)) == 0) {
+    p = sessbuf; 
+    while (*p != 0 && *p != '.') { 
+      p++; 
+    };
+    *p = 0;
+    strncat(sessbuf, ":", 512); 
+    strncat(sessbuf, tty0, 512);
+  } else {
+    strncpy(sessbuf, tty0, 512);
+  }
+  DEBUG("Generated sessid: %s",sessbuf);
+  strcpy(id,sessbuf);
+  return result;
+}
+
+int
+getDisplay(char *tty, char *rhost, char *service, char *display)
+{
+  int result=PAM_SUCCESS;
+  if (strcmp(service,"dtlogin") != 0) {
+    strcpy(display,tty);
+  } else /* dtlogin */ {
+/*      char *DISPLAY=getenv("DISPLAY"); */
+/*      NOTNULL(DISPLAY); */
+/*      DEBUG("DISPLAY=%s",DISPLAY); */
+/*      strcpy(display,DISPLAY); */
+    NOTNULL(rhost);
+    strcpy(display,rhost);
+    DEBUG("display=%s",display);
+  }
+  return result;
+}
+
+int
+cookDisplay(char *tty, char *from)
+{
+  int result=PAM_SUCCESS;
+  char tmp[RANDOM_LENGTH];
+  NOTNULL(tty);
+  NOTNULL(from);
+  result=cut(tty,':',1,from);
+  DEBUG("cut field 1 from '%s' with delimiter ':' yielded '%s'", tty, from);
+  ASSERT;
+  if (strcmp(from,tty)==0 || strcmp(from,"")==0) {
+    char hostname[RANDOM_LENGTH];
+    if (gethostname(hostname,RANDOM_LENGTH)!=0) {
+      PERROR("gethostname failed");
+      result=PAM_SESSION_ERR;
+      return result;
+    }
+    DEBUG("got hostname '%s'", hostname);
+    strcpy(from,hostname);
+    strcpy(tmp,hostname);
+    strcat(tmp,tty);
+    strcpy(tty,tmp);
+  }
+  return result;
+}
+
+int
+getLocation(char *rhost, char *location)
+{
+  int result=PAM_SUCCESS;
+  char *nisDomain;
+  char *val;
+  int len;
+  int yperr;
+  NOTNULL(rhost);
+  NOTNULL(location);
+  // Try ypprot_err(yperr) if you get meaningless errors
+  yperr=yp_get_default_domain(&nisDomain);
+  YP_ASSERT;
+  DEBUG("Got NIS domain '%s'",nisDomain);
+  yperr=yp_match(nisDomain,
+		 "labterm",
+		 rhost,
+		 strlen(rhost),
+		 &val,
+		 &len);
+  YP_ASSERT;
+  NOTNULL(val);
+  DEBUG("Got value '%s' for key '%s'",val,rhost);
+  NONZERO(len);
+  result=cut(val,' ',2,location);
+  ASSERT;
+  result=stripCRLF(location);
+  ASSERT;
+  return result;
+}
+
+int
+stripCRLF(char *s)
+{
+  int result=PAM_SUCCESS;
+  int len;
+  NOTNULL(s);
+  len=strlen(s);
+  DEBUG("last byte of '%s' has value '%d'",s,s[len-1]);
+  if (s[len-1] == '\n') {
+    DEBUG("stripping CRLF from '%s'",s);
+    s[len-1] = '\0';
+  }
+  return result;
+}
+  
+/**
+ *
+ * If the delimiter does not appear, make target empty
+ * If the field index is too big, make target empty
+ * Otherwise, copy the field into target
+ *
+ */
+int
+cut(char *source,char delimiter,int field,char *target)
+{
+  int result=PAM_SUCCESS;
+  int fieldCount=1;
+  int i=0;
+  int j=0;
+  NOTNULL(source);
+  NOTNULL(target);
+  target[j]='\0';
+  while ((source[i] != '\0') && (fieldCount <= field)) {
+    if (source[i] == delimiter) {
+      fieldCount++;
+      i++;
+      continue;
+    }
+    if (fieldCount == field) {
+      target[j++]=source[i++];
+    } else {
+      i++;
+    }
+  }
+  target[j]='\0';
+  return result;
+}

--- a/util.h
+++ b/util.h
@@ -1,0 +1,43 @@
+#ifndef UTIL_H
+#define UTIL_H
+
+int
+getHomeDir(char *user, char *homeDir);
+
+int 
+getUID(char *user);
+
+int
+isDebuggingOn();
+
+void
+turnOnDebugging();
+
+int
+isGdbEnabled();
+
+void
+enableGdb();
+
+int
+cut(char *source,char limiter,int field,char *target);
+
+int
+stripCRLF(char *s);
+
+int
+getDisplay(char *tty, char *rhost, char *service, char *display);
+
+void
+cookService(char *service, char *cookedService);
+
+int
+cookDisplay(char *tty, char *from);
+
+int
+getLocation(char *rhost, char *location);
+
+int
+sessid(char *tty, char *id);
+
+#endif

--- a/varargs.h
+++ b/varargs.h
@@ -1,0 +1,28 @@
+#ifndef VARARGS_H
+#define VARARGS_H
+
+#ifdef SunOS
+
+#ifdef i386
+#include <stdarg.h>
+#define VA_LIST va_list
+#define VA_START(valist,first) va_start(valist,first)
+#define VA_ARG(valist,type) va_arg(valist,type)
+#define VA_END(valist) va_end(valist)
+#else
+#include <sys/varargs.h>
+#define VA_LIST va_list
+#define VA_START(valist,first) va_start(valist,first)
+#define VA_ARG(valist,type) va_arg(valist,type)
+#define VA_END(valist) va_end(valist)
+#endif
+
+#else
+#include <stdarg.h>
+#define VA_LIST va_list
+#define VA_START(valist,first) va_start(valist,first)
+#define VA_ARG(valist,type) va_arg(valist,type)
+#define VA_END(valist) va_end(valist)
+#endif
+
+#endif


### PR DESCRIPTION
This is some C code I wrote in 2003 while working at the Computer Science department at UBC. I open-sourced it at the time (with permission) by uploading the code to SourceForge. 

We had a network of machines running different Unix-like operating systems -- mostly Linux and Solaris. At some point we wanted to harden user password security by running user passwords against Cracklib to see if they are easily cracked. This needed to happen at login time: the user would be prompted to change the password if it was too weak. 

On Linux we implemented this by installing the pam_cracklib PAM (Pluggable Authentication) module. The PAM modules are shared libraries (`.so`'s) referenced from a config file (`/etc/pam.conf` if memory serves) in a chained configuration: the authentication flows from one PAM module to the next. In order to successfully authenticate, all modules in the chain must approve the authentication attempt. 

This scheme worked pretty much out-of-the-box on Linux. We were unable to get the Linux module working on our Solaris machines, though. So, I decided to roll my own. 

I never achieved Internet fame with this codebase, but I did receive reports of several people (!) using it. 

Reading my code some 18 years later is a nostalgic exercise. The reviewer will note delightful anachronisms such as the eight-character limit on password length imposed by our NIS (user directory) at the time. The code contains some editorial comments that I would probably not have shared with the world today. I've decided to leave them in place for historical authenticity. 